### PR TITLE
Update travis configuration for repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 2.2.3
+
 before_install: gem install bundler -v 1.11.2
+
+# Have this option to stop travis-ci building twice. Currently we have travis set to build both
+# PR's and pushes. However this means when we push to a PR we have to wait for Travis to finish
+# 2 builds. If we unticked 'pushes' when the PR was finally merged that would not be built. The
+# brute force approach would be to untick build PR's and just build all pushes. We instead have
+# gone with the approach outlined here http://stackoverflow.com/a/31882307
+branches:
+  only:
+    - master


### PR DESCRIPTION
This change makes the following changes to our Travis-CI configuration

- Stop travis building twice for a particular commit
- Cache dependencies between build